### PR TITLE
Fix double Faraday conn.send

### DIFF
--- a/lib/squall/support/base.rb
+++ b/lib/squall/support/base.rb
@@ -51,6 +51,9 @@ module Squall
         c.response :on_app_errors
         c.response :json
         c.adapter :net_http
+        if Squall.config[:debug]
+         c.use Faraday::Response::Logger
+        end
       end
       response = conn.send(request_method, path)
       @success = (200..207).include?(response.env[:status])

--- a/lib/squall/support/base.rb
+++ b/lib/squall/support/base.rb
@@ -57,7 +57,8 @@ module Squall
       end
       response = conn.send(request_method, path)
       @success = (200..207).include?(response.env[:status])
-      @result = conn.send(request_method, path).body
+  #    @result = conn.send(request_method, path).body
+      @result = response.body
     end
 
     # Raises an error if a request is made without first calling Squall.config


### PR DESCRIPTION
There was a stupid bug in the Faraday routine that caused the post to the OnApp to happen twice. This pull req fixes this. It also makes the debug config work again as well :)
