### PR TITLE
Remove Ruby 1.8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,7 @@ notifications:
     on_success: never
     on_failure: always
 rvm:
-  - 1.8.7
   - 1.9.2
   - 1.9.3
-  - ree
-  - jruby-18mode
+  - 2.0.0
   - jruby-19mode

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Squall [![Squall Build Status][Build Icon]][Build Status]
 
 A Ruby library for working with the [OnApp REST API][].
 
-Squall has been tested on MRI 1.8.7, MRI 1.9.2, MRI 1.9.3 Preview 1,
+Squall has been tested on MRI 1.9.2, MRI 1.9.3, MRI 2.0.0,
 Rubinius 2.0.0pre, and JRuby 1.6.2.
 
 Documentation is available in [RDoc][] format.

--- a/lib/squall.rb
+++ b/lib/squall.rb
@@ -3,7 +3,6 @@ require 'faraday_middleware'
 
 require 'squall/support/version'
 require 'squall/support/exception'
-require 'squall/support/yaml'
 
 module Squall
   # Support

--- a/lib/squall/data_store_zone.rb
+++ b/lib/squall/data_store_zone.rb
@@ -28,7 +28,7 @@ module Squall
     #
     # * +label*+ - Label for the data store zone
     def edit(id, options = {})
-      response = request(:put, "/data_store_zones/#{id}.json", :query => {:pack => options})
+      request(:put, "/data_store_zones/#{id}.json", query: { pack: options })
     end
 
     # Creates a new DataStoreZone
@@ -41,7 +41,7 @@ module Squall
     #
     # * +label*+ - Label for the data store zone
     def create(options = {})
-      response = request(:post, "/data_store_zones.json", :query => {:pack => options})
+      request(:post, "/data_store_zones.json", query: { pack: options })
     end
 
     # Deletes an existing DataStoreZone

--- a/lib/squall/disk.rb
+++ b/lib/squall/disk.rb
@@ -183,6 +183,5 @@ module Squall
     def delete(id)
       request(:delete, "/settings/disks/#{id}.json")
     end
-
   end
 end

--- a/lib/squall/firewall_rule.rb
+++ b/lib/squall/firewall_rule.rb
@@ -31,7 +31,7 @@ module Squall
     #   create :command              => "DROP",
     #          :protocol             => "TCP",
     #          :network_interface_id => 1
-    def create(vm_id, options={})
+    def create(vm_id, options = {})
       request(:post, "/virtual_machines/#{vm_id}/firewall_rules.json", default_params(options))
     end
 
@@ -46,7 +46,7 @@ module Squall
     # ==== Options
     #
     # See #create
-    def edit(vm_id, id, options={})
+    def edit(vm_id, id, options = {})
       request(:put, "/virtual_machines/#{vm_id}/firewall_rules/#{id}.json", default_params(options))
     end
 

--- a/lib/squall/hypervisor.rb
+++ b/lib/squall/hypervisor.rb
@@ -52,7 +52,7 @@ module Squall
     # ==== Example
     #
     #   edit 1, :label => 'myhv', :ip_address => '127.0.0.1'
-    def edit(id, options ={})
+    def edit(id, options = {})
       request(:put, "/settings/hypervisors/#{id}.json", default_params(options))
     end
 
@@ -86,7 +86,7 @@ module Squall
     end
 
     def add_data_store_join(id, data_store_id)
-      request(:post, "/settings/hypervisors/#{id}/data_store_joins.json", :query => {:data_store_id => data_store_id})
+      request(:post, "/settings/hypervisors/#{id}/data_store_joins.json", query: { data_store_id:  data_store_id })
     end
 
     def remove_data_store_join(id, data_store_join_id)
@@ -99,7 +99,7 @@ module Squall
     end
 
     def add_network_join(id, options)
-      request(:post, "/settings/hypervisors/#{id}/network_joins.json", :query => {:network_join => options})
+      request(:post, "/settings/hypervisors/#{id}/network_joins.json", query: { network_join: options })
     end
 
     def remove_network_join(id, network_join_id)

--- a/lib/squall/hypervisor_zone.rb
+++ b/lib/squall/hypervisor_zone.rb
@@ -28,7 +28,7 @@ module Squall
     #
     # See #create
     def edit(id, options = {})
-      response = request(:put, "/settings/hypervisor_zones/#{id}.json", :query => {:pack => options})
+      request(:put, "/settings/hypervisor_zones/#{id}.json", query:  { pack: options })
     end
 
     # Creates a new hypervisor zone
@@ -41,7 +41,7 @@ module Squall
     #
     # * +label*+ - Label for the hypervisor zone
     def create(options = {})
-      response = request(:post, "/settings/hypervisor_zones.json", :query => {:pack => options})
+      request(:post, "/settings/hypervisor_zones.json", query: { pack: options })
     end
 
     # Deletes an existing hypervisor zone
@@ -80,7 +80,7 @@ module Squall
     # * +id*+ - ID of the hypervisor zone
     # * +data_store_id*+ - ID of the data store
     def add_data_store_join(id, data_store_id)
-      request(:post, "/settings/hypervisor_zones/#{id}/data_store_joins.json", :query => {:data_store_id => data_store_id})
+      request(:post, "/settings/hypervisor_zones/#{id}/data_store_joins.json", query: { data_store_id: data_store_id })
     end
 
     # Remove a data store from a hypervisor zone
@@ -115,7 +115,7 @@ module Squall
     # * +network_id*+ - The ID of the network to add to the hypervisor zone
     # * +interface*+ - The name of the appropriate network interface
     def add_network_join(id, options={})
-      request(:post, "/settings/hypervisor_zones/#{id}/network_joins.json", :query => {:network_join => options})
+      request(:post, "/settings/hypervisor_zones/#{id}/network_joins.json", query: { network_join:  options })
     end
 
     # Remove a network from a hypervisor zone

--- a/lib/squall/ip_address.rb
+++ b/lib/squall/ip_address.rb
@@ -23,7 +23,7 @@ module Squall
     #
     # See #create
     def edit(network_id, id, options = {})
-      response = request(:put, "/settings/networks/#{network_id}/ip_addresses/#{id}.json", default_params(options))
+      request(:put, "/settings/networks/#{network_id}/ip_addresses/#{id}.json", default_params(options))
     end
 
     # Creates a new IpAddress
@@ -42,7 +42,7 @@ module Squall
     # * +gateway*+ - Gateway address
     # * +disallowed_primary+ - Set to '1' to prevent this address being used as primary
     def create(network_id, options = {})
-      response = request(:post, "/settings/networks/#{network_id}/ip_addresses.json", default_params(options))
+      request(:post, "/settings/networks/#{network_id}/ip_addresses.json", default_params(options))
     end
 
     # Deletes an existing ip address

--- a/lib/squall/network_zone.rb
+++ b/lib/squall/network_zone.rb
@@ -27,7 +27,7 @@ module Squall
     #
     # See #create
     def edit(id, options = {})
-      response = request(:put, "/network_zones/#{id}.json", :query => {:pack => options})
+      request(:put, "/network_zones/#{id}.json", query:  { pack: options })
     end
 
     # Creates a new network zone
@@ -36,7 +36,7 @@ module Squall
     #
     # * +label*+ - Label for the network zone
     def create(options = {})
-      response = request(:post, "/network_zones.json", :query => {:pack => options})
+      request(:post, "/network_zones.json", query: { pack: options })
     end
 
     # Deletes an existing network zone

--- a/lib/squall/support/base.rb
+++ b/lib/squall/support/base.rb
@@ -18,7 +18,7 @@ module Squall
     #
     #   default_params(:something => 1)
     def default_params(*options)
-      options.empty? ? {} : {:query => { key_for_class => options.first}}
+      options.empty? ? {} : { query: { key_for_class => options.first } }
     end
 
     # Peforms an HTTP Request
@@ -35,7 +35,7 @@ module Squall
     def request(request_method, path, options = {})
       check_config
 
-      conn = Faraday.new(:url => Squall.config[:base_uri]) do |c|
+      conn = Faraday.new(url: Squall.config[:base_uri]) do |c|
         c.basic_auth Squall.config[:username], Squall.config[:password]
         c.params = (options[:query] || {})
         c.request :url_encoded

--- a/lib/squall/support/yaml.rb
+++ b/lib/squall/support/yaml.rb
@@ -1,5 +1,0 @@
-require 'yaml'
-
-if ::YAML.const_defined?(:ENGINE)
-  ::YAML::ENGINE.yamler = 'syck'
-end

--- a/lib/squall/user.rb
+++ b/lib/squall/user.rb
@@ -7,7 +7,6 @@ module Squall
       response.collect { |user| user['user'] }
     end
 
-
     # Create a new User
     #
     # ==== Params
@@ -124,7 +123,7 @@ module Squall
     #
     # * +id*+ - ID of user
     def monthly_bills(id)
-      response = request(:get, "/users/#{id}/monthly_bills.json")
+      request(:get, "/users/#{id}/monthly_bills.json")
     end
 
     # Return a list of VirtualMachines for a User

--- a/lib/squall/virtual_machine.rb
+++ b/lib/squall/virtual_machine.rb
@@ -103,7 +103,7 @@ module Squall
     # * +id*+ - ID of the virtual machine
     # * +user_id*+ - ID of the target User
     def change_owner(id, user_id)
-      response = request(:post, "/virtual_machines/#{id}/change_owner.json", :query => { :user_id => user_id })
+      response = request(:post, "/virtual_machines/#{id}/change_owner.json", query: { user_id: user_id })
       response['virtual_machine']
     end
 
@@ -114,7 +114,7 @@ module Squall
     # * +id*+ - ID of the virtual machine
     # * +password*+ - New password
     def change_password(id, password)
-      response = request(:post, "/virtual_machines/#{id}/reset_password.json", :query => { :new_password => password })
+      response = request(:post, "/virtual_machines/#{id}/reset_password.json", query: { new_password: password })
       response['virtual_machine']
     end
 
@@ -140,7 +140,7 @@ module Squall
     # * +destination*+ - ID of a hypervisor to which to migrate the virtual machine
     # * +cold_migrate_on_rollback+ - Set to '1' to switch to cold migration if migration fails
     def migrate(id, options = {})
-      response = request(:post, "/virtual_machines/#{id}/migrate.json", :query => {:virtual_machine => options} )
+      request(:post, "/virtual_machines/#{id}/migrate.json", query: { virtual_machine: options } )
     end
 
     # Toggle the VIP status of the virtual machine
@@ -237,7 +237,7 @@ module Squall
     # * +id*+ - ID of the virtual machine
     # * +recovery+ - Set to true to reboot in recovery, defaults to false
     def reboot(id, recovery=false)
-      response = request(:post, "/virtual_machines/#{id}/reboot.json", {:query => recovery ? {:mode => :recovery} : nil})
+      response = request(:post, "/virtual_machines/#{id}/reboot.json", { query: recovery ? { mode: :recovery } : nil })
       response['virtual_machine']
     end
 
@@ -248,7 +248,7 @@ module Squall
     # * +id*+ - ID of the virtual machine
     # * +target_vm_id+* - ID of another virtual machine from which it should be segregated
     def segregate(id, target_vm_id)
-      response = request(:post, "/virtual_machines/#{id}/strict_vm.json", default_params(:strict_virtual_machine_id => target_vm_id))
+      response = request(:post, "/virtual_machines/#{id}/strict_vm.json", default_params(strict_virtual_machine_id: target_vm_id))
       response['virtual_machine']
     end
 

--- a/lib/squall/whitelist.rb
+++ b/lib/squall/whitelist.rb
@@ -40,7 +40,7 @@ module Squall
     #   create :ip          => 192.168.1.1,
     #          :description => "Computer that someone I trust uses"
     def create(user_id, options={})
-      request(:post, "/users/#{user_id}/user_white_lists.json", :query => {:user_white_list => options})
+      request(:post, "/users/#{user_id}/user_white_lists.json", query: { user_white_list: options })
     end
 
     # Edit a whitelist
@@ -55,7 +55,7 @@ module Squall
     #
     # See #create
     def edit(user_id, id, options={})
-      request(:put, "/users/#{user_id}/user_white_lists/#{id}.json", :query => {:user_white_list => options})
+      request(:put, "/users/#{user_id}/user_white_lists/#{id}.json", query: { user_white_list: options })
     end
 
     # Delete a whitelist

--- a/squall.gemspec
+++ b/squall.gemspec
@@ -3,6 +3,8 @@ $:.push File.expand_path("../lib", __FILE__)
 require "squall/support/version"
 
 Gem::Specification.new do |s|
+  s.required_ruby_version = Gem::Requirement.new(">= 1.9.2")
+
   s.name        = "squall"
   s.version     = Squall::VERSION
   s.platform    = Gem::Platform::RUBY


### PR DESCRIPTION
Ruby 1.8.7 reaches end of life this month. This PR removes a YAML hack used for Ruby 1.8 and uses 1.9 style hashes under `lib/`.

This will fix the `syck has been removed` error we see on projects using Squall.
