### PR TITLE
Proposal: Use GitHub Pages to store docs

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,4 +1,0 @@
---readme README.md
---private
---plugin tomdoc
-lib

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Documentation is available in [TomDoc][] format.
 [Build Status]: http://travis-ci.org/site5/squall
 [Build Icon]: https://secure.travis-ci.org/site5/squall.png?branch=master
 [OnApp REST API]: https://help.onapp.com/manual.php?m=2
-[TomDoc]: http://rdoc.info/github/site5/squall/master/frames
+[TomDoc]: http://site5.github.io/squall/
 
 Install
 -------

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,6 @@
 require 'bundler'
 require 'uri'
+require 'rake-tomdoc'
 begin
   require 'rspec/core/rake_task'
 rescue LoadError

--- a/squall.gemspec
+++ b/squall.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'vcr', '~> 1.8'
   s.add_development_dependency 'awesome_print', '~> 1.0.2'
   s.add_development_dependency 'rake', '~> 0.9.2.2'
+  s.add_development_dependency 'rake-tomdoc', '~> 0.0.1'
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")


### PR DESCRIPTION
**REVIEW ONLY**

Unfortunately, rdoc.info does not support TomDoc. This is a proposal to use GitHub Pages instead.

The idea here is that we will run `rake tomdoc` with a new release. That task will:
1. Generate the docs in a temporary directory
2. Clean the git index
3. Checkout the `gh-pages` branch
4. Copy the docs from the temporary directory
5. Notify the user to review/commit changes

Once we push the changes to GitHub, they'll be available at http://site5.github.io/squall. We could also setup a custom domain, like gh.eng5.com/squall.

Thoughts?
