### PR TITLE
Require yaml in squall.rb

### DIFF
--- a/lib/squall.rb
+++ b/lib/squall.rb
@@ -1,3 +1,4 @@
+require 'yaml'
 require 'faraday'
 require 'faraday_middleware'
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,3 @@
-require 'yaml'
 require 'rspec'
 require 'vcr'
 require 'squall'


### PR DESCRIPTION
We were requiring YAML inside of `spec_helper.rb` instead of inside of `squall.rb`. This broke some things if you attempted to use Squall before some other library loaded YAML.

```
~/work/squall % bundle console
Resolving dependencies...
2.0.0-p353> Squall.config_file
NameError: uninitialized constant Squall::YAML
    from /Users/priddle/work/squall/lib/squall.rb:83:in `block in config_file'
    from /Users/priddle/work/squall/lib/squall.rb:56:in `config'
    from /Users/priddle/work/squall/lib/squall.rb:82:in `config_file'
    from (irb):2
    from /Users/priddle/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/bundler-1.5.3/lib/bundler/cli.rb:666:in `console'
    from /Users/priddle/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/bundler-1.5.3/lib/bundler/vendor/thor/command.rb:27:in `run'
    from /Users/priddle/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/bundler-1.5.3/lib/bundler/vendor/thor/invocation.rb:121:in `invoke_command'
    from /Users/priddle/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/bundler-1.5.3/lib/bundler/vendor/thor.rb:363:in `dispatch'
    from /Users/priddle/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/bundler-1.5.3/lib/bundler/vendor/thor/base.rb:440:in `start'
    from /Users/priddle/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/bundler-1.5.3/lib/bundler/cli.rb:10:in `start'
    from /Users/priddle/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/bundler-1.5.3/bin/bundle:20:in `block in <top (required)>'
    from /Users/priddle/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/bundler-1.5.3/lib/bundler/friendly_errors.rb:5:in `with_friendly_errors'
    from /Users/priddle/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/bundler-1.5.3/bin/bundle:20:in `<top (required)>'
    from /Users/priddle/.rbenv/versions/2.0.0-p353/bin/bundle:23:in `load'
    from /Users/priddle/.rbenv/versions/2.0.0-p353/bin/bundle:23:in `<main>'
2.0.0-p353> require 'yaml'
=> true
2.0.0-p353> Squall.config_file
=> {:username=>"noidea", :password=>"no no no", :base_uri=>"http://example.com/", :debug=>true}
```
