### PR TITLE
Update rake-tomdoc

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
 source "http://rubygems.org"
 
 gemspec
+
+gem 'rake-tomdoc', github: 'site5/rake-tomdoc'

--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,4 @@ source "http://rubygems.org"
 
 gemspec
 
-gem 'rake-tomdoc', github: 'site5/rake-tomdoc'
+gem 'rake-tomdoc', github: 'site5/rake-tomdoc', branch: 'kramdown'

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,3 @@
 source "http://rubygems.org"
 
 gemspec
-
-gem 'rake-tomdoc', github: 'site5/rake-tomdoc', branch: 'kramdown'

--- a/Rakefile
+++ b/Rakefile
@@ -1,9 +1,9 @@
 begin
   require 'bundler/gem_tasks'
   require 'rspec/core/rake_task'
-  require 'rake-tomdoc'
+  require 'rake-tomdoc' unless RUBY_PLATFORM == 'java'
 rescue LoadError
-  abort "Please install rspec (bundle install)"
+  abort "Please run `bundle install` first"
 end
 
 RSpec::Core::RakeTask.new :spec

--- a/squall.gemspec
+++ b/squall.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'vcr', '~> 1.8'
   s.add_development_dependency 'awesome_print', '~> 1.0.2'
   s.add_development_dependency 'rake', '~> 0.9.2.2'
-  s.add_development_dependency 'rake-tomdoc', '~> 0.0.2'
+  s.add_development_dependency 'rake-tomdoc', '~> 0.0.2' unless RUBY_PLATFORM == 'java'
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")


### PR DESCRIPTION
`rake-tomdoc` v0.0.2 used Redcarpet which lacks jRuby support. The (pending) v0.0.3 release uses Kramdown, a pure Ruby alternative.
